### PR TITLE
Update Decompress1X handling of runtime error for Go1.13.

### DIFF
--- a/decompress.go
+++ b/decompress.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"io"
 	"runtime"
+	"strings"
 )
 
 var (
@@ -157,7 +158,7 @@ func Decompress1X(r io.Reader, inLen int, outLen int) (out []byte, err error) {
 		// as the reading functions are very hot in the decompressor.
 		if r := recover(); r != nil {
 			if re, ok := r.(runtime.Error); ok {
-				if re.Error() == "runtime error: index out of range" {
+				if strings.HasPrefix(re.Error(), "runtime error: index out of range") {
 					err = io.EOF
 					return
 				}


### PR DESCRIPTION
Upcoming Go 1.13 change https://golang.org/cl/161477 updates the runtime
error strings for index out of range errors.

This change simply makes the comparison a bit more loose to handle both
pre-1.13 and 1.13.